### PR TITLE
Remove the MapLibre location service (as its whack) and provide our own geotracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@gorhom/bottom-sheet": "^5",
     "@maplibre/maplibre-react-native": "^10.1.0",
+    "@react-native-community/geolocation": "^3.4.0",
     "@react-navigation/native": "^7.0.15",
     "@react-navigation/native-stack": "^7.2.1",
     "@turf/turf": "^7.2.0",

--- a/src/config/MapConfigContext.tsx
+++ b/src/config/MapConfigContext.tsx
@@ -3,6 +3,8 @@ import MAP_STYLE, {DEFAULT_CENTER} from './MapConfig.ts';
 import {CameraRef, LocationManager} from '@maplibre/maplibre-react-native';
 import {IMapConfig, IMapConfigContext} from '../interfaces/MapConfig.ts';
 
+import useLocation from '../hooks/UseLocation.tsx';
+
 
 const defaultConfig: IMapConfig = {
     mapStyle: MAP_STYLE,
@@ -12,6 +14,8 @@ const defaultConfig: IMapConfig = {
 const MapConfigContext = createContext<IMapConfigContext>({
     config: defaultConfig,
     loading: true,
+    userLocation: null,
+    hasLocationPermission: false,
     handleRecenter: () => {},
 });
 
@@ -19,6 +23,7 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
     const [config, setConfig] = useState<IMapConfig>(defaultConfig);
     const [loading, setLoading] = useState(true);
     const cameraRef = useRef<CameraRef>(null);
+    const { hasLocationPermission, userLocation } = useLocation();
 
     useEffect(() => {
         const loadConfig = async () => {
@@ -51,7 +56,16 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
     };
 
     return (
-        <MapConfigContext.Provider value={{config, loading, cameraRef, handleRecenter}}>
+        <MapConfigContext.Provider value={
+            {
+                config,
+                userLocation,
+                hasLocationPermission,
+                loading,
+                cameraRef,
+                handleRecenter,
+            }
+        }>
             {children}
         </MapConfigContext.Provider>
     );

--- a/src/hooks/UseLocation.tsx
+++ b/src/hooks/UseLocation.tsx
@@ -1,9 +1,17 @@
-import React, {useEffect} from 'react';
+import Geolocation from '@react-native-community/geolocation';
+import React, {useEffect, useState} from 'react';
 import {Platform} from 'react-native';
 import {PermissionsAndroid} from 'react-native';
 
+
+/**
+ * According to react-native this functions as hook to get the user's location
+ * BUT here it is not a hook, geolocation makes it so a watcher is created everytime this hook gets called
+ * To counter that this should only be called ONCE in a provider
+ */
 const UseLocation = () => {
-    const [hasPermission, setHasPermission] = React.useState<boolean>(false);
+    const [hasLocationPermission, setHasLocationPermission] = React.useState<boolean>(false);
+    const [userLocation, setUserLocation] = useState<[number, number] | null>(null);
 
     useEffect(() => {
         const requestPermission = async () => {
@@ -12,17 +20,41 @@ const UseLocation = () => {
                     PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
                 );
 
-                setHasPermission(granted === PermissionsAndroid.RESULTS.GRANTED);
+                setHasLocationPermission(granted === PermissionsAndroid.RESULTS.GRANTED);
             } else {
-                setHasPermission(true); // iOS handles this via Info.plist
+                setHasLocationPermission(true); // iOS handles this via Info.plist
             }
         };
 
         requestPermission();
-    });
+    }, []);
+
+    useEffect(() => {
+        let watchId: number | null = null;
+
+        if (hasLocationPermission) {
+            watchId = Geolocation.watchPosition(
+                (position) => {
+                    setUserLocation([position.coords.longitude, position.coords.latitude]);
+                } ,
+                (error) => console.warn('GeoLocation error:', error),
+                {
+                    enableHighAccuracy: true,
+                    distanceFilter: 5,
+                    interval: 3000,
+                }
+            );
+        }
+
+        return () => {
+            if (watchId) {
+                Geolocation.clearWatch(watchId);
+            }
+        };
+    }, [hasLocationPermission]);
 
 
-    return { hasPermission };
+    return { hasLocationPermission, userLocation };
 };
 
 export default UseLocation;

--- a/src/interfaces/MapConfig.ts
+++ b/src/interfaces/MapConfig.ts
@@ -9,6 +9,8 @@ export interface IMapConfig {
 export interface IMapConfigContext {
     config: IMapConfig,
     loading: boolean,
+    userLocation: [number, number] | null,
+    hasLocationPermission: boolean,
     cameraRef?: React.RefObject<CameraRef | null>,
     handleRecenter: () => void,
 }

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import {useMapConfig} from '../config/MapConfigContext.tsx';
-import useLocation from '../hooks/UseLocation.tsx';
 import Loader from '../components/Loader.tsx';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
-import {Camera, MapView, UserLocation} from '@maplibre/maplibre-react-native';
+import {Camera, MapView, PointAnnotation} from '@maplibre/maplibre-react-native';
 import {Icon} from 'react-native-paper';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -11,13 +10,14 @@ const MapScreen = () => {
     const {
         config,
         loading,
+        hasLocationPermission,
+        userLocation,
         cameraRef,
         handleRecenter,
     } = useMapConfig();
-    const { hasPermission } = useLocation();
     const insets = useSafeAreaInsets();
 
-    if (loading || !hasPermission) {
+    if (loading || !hasLocationPermission) {
         return <Loader />;
     }
 
@@ -30,9 +30,16 @@ const MapScreen = () => {
                 <Camera
                     ref={cameraRef}
                     centerCoordinate={config.center}
+                    followUserLocation={false}
                 />
 
-                <UserLocation showsUserHeadingIndicator={true}/>
+                {userLocation && (
+                    <PointAnnotation id="user-location" coordinate={userLocation}>
+                        <View
+                            style={styles.mapUserMarker}
+                        />
+                    </PointAnnotation>
+                )}
             </MapView>
 
             <View
@@ -58,6 +65,14 @@ const styles = StyleSheet.create({
     },
     map: {
         flex: 1,
+    },
+    mapUserMarker: {
+        width: 18,
+        height: 18,
+        borderRadius: 10,
+        backgroundColor: '#0017EE',
+        borderWidth: 2,
+        borderColor: '#fff',
     },
     controls: {
         position: 'absolute',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,11 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
+"@react-native-community/geolocation@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/geolocation/-/geolocation-3.4.0.tgz#8b6ee024a71cf94526ab796af1e9ae140684802c"
+  integrity sha512-bzZH89/cwmpkPMKKveoC72C4JH0yF4St5Ceg/ZM9pA1SqX9MlRIrIrrOGZ/+yi++xAvFDiYfihtn9TvXWU9/rA==
+
 "@react-native/assets-registry@0.78.0":
   version "0.78.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.78.0.tgz#e18165f05424bfd2240662ee1dcc4e13a3b9dab8"


### PR DESCRIPTION
The mapLibre location services uitilizes a locationManager, but this one doesn't really seem to work well and is poorly documented. Instead I added a custom addition to the location hook to fetch our location using the geolocation community package. 