### PR TITLE
Add a custom snackbar and add screenState to the map to track if user is suggesting

### DIFF
--- a/src/components/CustomSnackbar.tsx
+++ b/src/components/CustomSnackbar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import BaseSnackbar from './base/baseSnackbar.tsx';
+
+
+interface CustomSnackbarProps {
+    visible: boolean;
+    dismissSnackBar: (callback?: () => void) => void;
+    message: string;
+}
+
+export default function CustomSnackbar({
+    visible,
+    dismissSnackBar,
+    message,
+}: CustomSnackbarProps) {
+    return (
+        <BaseSnackbar
+            visible={visible}
+            dismissSnackBar={dismissSnackBar}
+        >
+            {message}
+        </BaseSnackbar>
+    );
+}

--- a/src/components/base/baseSnackbar.tsx
+++ b/src/components/base/baseSnackbar.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {Snackbar, useTheme} from 'react-native-paper';
+
+interface BaseSnackbarProps {
+    children: React.ReactNode;
+    visible: boolean;
+    dismissSnackBar: (callback?: () => void) => void;
+    icon?: string;
+    action?: {
+        label: string;
+        onPress: () => void;
+    }
+}
+
+export default function BaseSnackbar({
+    children,
+    icon,
+    visible,
+    dismissSnackBar,
+    action,
+}: BaseSnackbarProps) {
+    const theme = useTheme();
+
+    return (
+        <Snackbar
+            elevation={3}
+            icon={icon}
+            onIconPress={dismissSnackBar}
+            visible={visible}
+            onDismiss={dismissSnackBar}
+            action={action}
+            theme={theme}
+        >
+            {children}
+        </Snackbar>
+    );
+}

--- a/src/components/map/MapCenterButton.tsx
+++ b/src/components/map/MapCenterButton.tsx
@@ -33,7 +33,6 @@ const getStyles = (theme: MD3Theme) =>
     StyleSheet.create({
         controls: {
             position: 'absolute',
-            zIndex: 1,
         },
 
         button: {

--- a/src/components/map/SuggestPOIButton.tsx
+++ b/src/components/map/SuggestPOIButton.tsx
@@ -6,13 +6,14 @@ import { EdgeInsets, useSafeAreaInsets} from 'react-native-safe-area-context';
 
 interface props {
     handleCreateSuggestion: () => void;
+    active: boolean
 }
 
 
-export default function SuggestPOIButton({handleCreateSuggestion}: props) {
+export default function SuggestPOIButton({handleCreateSuggestion, active}: props) {
     const theme = useTheme();
     const insets = useSafeAreaInsets();
-    const styles = getStyles(theme, insets);
+    const styles = getStyles(theme, insets, active);
 
     return (
         <View style={styles.container}>
@@ -24,7 +25,7 @@ export default function SuggestPOIButton({handleCreateSuggestion}: props) {
     );
 }
 
-const getStyles = (theme: MD3Theme, insets: EdgeInsets) =>
+const getStyles = (theme: MD3Theme, insets: EdgeInsets, active: boolean) =>
     StyleSheet.create({
         container: {
             backgroundColor: theme.colors.background,
@@ -44,6 +45,7 @@ const getStyles = (theme: MD3Theme, insets: EdgeInsets) =>
         },
 
         suggestButton: {
+            backgroundColor: active ? theme.colors.primary : theme.colors.background,
             width: '100%',
             paddingVertical: 8,
             justifyContent: 'center',
@@ -53,8 +55,8 @@ const getStyles = (theme: MD3Theme, insets: EdgeInsets) =>
         },
 
         suggestButtonText: {
+            color: active ? theme.colors.background : theme.colors.primary,
             fontSize: 14,
-            color: '#000',
             textAlign: 'center',
         },
     });

--- a/src/config/MapConfigContext.tsx
+++ b/src/config/MapConfigContext.tsx
@@ -1,8 +1,8 @@
 import React, {createContext, useContext, useEffect, useRef, useState} from 'react';
-import MAP_STYLE, {DEFAULT_CENTER, DEFAULT_ZOOM, MIN_ZOOM, MAX_ZOOM} from './MapConfig.ts';
+import MAP_STYLE, {DEFAULT_CENTER, DEFAULT_ZOOM, MAX_ZOOM, MIN_ZOOM} from './MapConfig.ts';
 
 import {CameraRef} from '@maplibre/maplibre-react-native';
-import {IMapConfig, IMapConfigContext} from '../interfaces/MapConfig.ts';
+import {IMapConfig, IMapConfigContext, ScreenState} from '../interfaces/MapConfig.ts';
 import {POI} from '../models/POI/POI.ts';
 
 import useLocation from '../hooks/UseLocation.tsx';
@@ -20,6 +20,8 @@ const defaultConfig: IMapConfig = {
 const MapConfigContext = createContext<IMapConfigContext>({
     config: defaultConfig,
     pois: [],
+    screenState: ScreenState.VIEWING,
+    setScreenState: () => {},
     loading: true,
     userLocation: null,
     hasLocationPermission: false,
@@ -31,11 +33,13 @@ const MapConfigContext = createContext<IMapConfigContext>({
 export const MapConfigProvider = ({ children }: { children: React.ReactNode}) => {
     const [config, setConfig] = useState<IMapConfig>(defaultConfig);
     const [loading, setLoading] = useState(true);
+    const [pois, setPois] = useState<POI[]>([]);
+    const [screenState, setScreenState] = useState(ScreenState.VIEWING);
+
     const zoomRef  = useRef<number>(DEFAULT_ZOOM);
     const cameraRef = useRef<CameraRef>(null);
-    const { hasLocationPermission, userLocation } = useLocation();
 
-    const [pois, setPois] = useState<POI[]>([]);
+    const { hasLocationPermission, userLocation } = useLocation();
 
     useEffect(() => {
         const loadConfig = async () => {
@@ -97,6 +101,8 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
             {
                 config,
                 pois,
+                screenState,
+                setScreenState,
                 userLocation,
                 hasLocationPermission,
                 loading,

--- a/src/hooks/useSnackbar.tsx
+++ b/src/hooks/useSnackbar.tsx
@@ -1,0 +1,17 @@
+import { useCallback, useState} from 'react';
+
+
+const useSnackbar = () => {
+    const [visible, setVisible] = useState(false);
+
+    const toggleSnackBar = useCallback(() => setVisible(!visible), [visible]);
+    const dismissSnackBar = useCallback(() => setVisible(false), []);
+
+    return {
+        visible,
+        toggleSnackBar,
+        dismissSnackBar,
+    };
+};
+
+export default useSnackbar;

--- a/src/interfaces/MapConfig.ts
+++ b/src/interfaces/MapConfig.ts
@@ -10,9 +10,16 @@ export interface IMapConfig {
     maxZoom: number;
 }
 
+export enum ScreenState {
+    VIEWING,
+    SUGGESTING
+}
+
 export interface IMapConfigContext {
     config: IMapConfig,
     pois: POI[],
+    screenState: ScreenState,
+    setScreenState: (state: ScreenState) => void,
     loading: boolean,
     userLocation: [number, number] | null,
     hasLocationPermission: boolean,


### PR DESCRIPTION
A custom snackbar is added that can be generically used with the supplied hook. Besides that, a screen state was added to the map context provider to track whether the user is in `suggesting` state or just `viewing`. With this we can enable and disable the placing op suggested locations.