### PR TITLE
feature: replace button text and add appbar component for top and possible bottom

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,8 @@ import {MD3LightTheme, PaperProvider} from 'react-native-paper';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import {NavigationContainer} from '@react-navigation/native';
 import AppNavigator from './src/navigation/AppNavigator';
+import {AppbarProvider} from './src/context/AppbarContext.tsx';
+import AppbarContainer from './src/components/AppbarContainer.tsx';
 
 const theme = {
     ...MD3LightTheme,
@@ -33,7 +35,11 @@ function App(): React.JSX.Element {
         <PaperProvider theme={theme}>
             <NavigationContainer>
                 <BottomSheetModalProvider>
-                    <AppNavigator />
+                    <AppbarProvider>
+                        <AppbarContainer>
+                            <AppNavigator />
+                        </AppbarContainer>
+                    </AppbarProvider>
                 </BottomSheetModalProvider>
             </NavigationContainer>
         </PaperProvider>

--- a/src/components/AppbarContainer.tsx
+++ b/src/components/AppbarContainer.tsx
@@ -1,0 +1,86 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {Animated, StyleSheet, Text, View, LayoutChangeEvent} from 'react-native';
+import {Appbar} from 'react-native-paper';
+
+import {useAppbar} from '../context/AppbarContext';
+
+const AppbarContainer = ({children}: {children: React.ReactNode}) => {
+    const {appbarTitle, appbarActions, showAppbar, centerTitle, overlapContent} = useAppbar();
+    const [appbarHeight, setAppbarHeight] = useState(0);
+
+    const translateY = useRef(new Animated.Value(-100)).current;
+
+    useEffect(() => {
+        Animated.timing(translateY, {
+            toValue: showAppbar ? 0 : -appbarHeight,
+            duration: 300,
+            useNativeDriver: true,
+        }).start();
+    }, [showAppbar, translateY, appbarHeight]);
+
+    const handleLayout = (event: LayoutChangeEvent) => {
+        const {height} = event.nativeEvent.layout;
+        setAppbarHeight(height);
+    };
+
+    return (
+        <View style={[styles.wrapper]}>
+            <Animated.View
+                style={[
+                    styles.container,
+                    {transform: [{translateY}]},
+                    overlapContent && styles.absoluteContainer,
+                ]}
+                onLayout={handleLayout}
+            >
+                <Appbar.Header>
+                    <Appbar.Content
+                        title={
+                            <Text
+                                style={[
+                                    styles.title,
+                                    centerTitle && styles.centeredTitle,
+                                ]}
+                            >
+                                {appbarTitle}
+                            </Text>
+                        }
+                    />
+                    {appbarActions.map((action, index) => (
+                        <React.Fragment key={index}>{action}</React.Fragment>
+                    ))}
+                </Appbar.Header>
+            </Animated.View>
+
+            <View style={styles.content}>{children}</View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+    },
+    container: {
+        overflow: 'hidden',
+        zIndex: 1,
+    },
+    absoluteContainer: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+    },
+    centeredTitle: {
+        textAlign: 'center',
+    },
+    content: {
+        flex: 1,
+    },
+});
+
+export default AppbarContainer;

--- a/src/components/base/baseBottomSheet.tsx
+++ b/src/components/base/baseBottomSheet.tsx
@@ -10,6 +10,7 @@ interface BaseBottomSheetProps {
     index?: number;
     onChange?: (index: number) => void;
     onClose?: () => void;
+    enablePanDownToClose?: boolean;
     snapPoints?: (string | number)[];
     background?: string;
 }
@@ -19,6 +20,7 @@ export default function BaseBottomSheet({
     bottomSheetRef,
     onChange,
     onClose,
+    enablePanDownToClose = true,
     snapPoints = ["40%", "70%"],
     background = '#fff',
 }: BaseBottomSheetProps) {
@@ -37,7 +39,7 @@ export default function BaseBottomSheet({
         <BottomSheet
             ref={bottomSheetRef}
             snapPoints={snapPoints}
-            enablePanDownToClose
+            enablePanDownToClose={enablePanDownToClose}
             onChange={handleSheetChange}
             style={styles.bottomSheetContainer}
         >

--- a/src/components/map/MapCreateSuggestion.tsx
+++ b/src/components/map/MapCreateSuggestion.tsx
@@ -7,7 +7,7 @@ import SuggestLocationDataSheet from './suggestion/SuggestLocationDataSheet.tsx'
 import useBottomSheets from '../../hooks/useBottomSheet.tsx';
 import useSnackbar from '../../hooks/useSnackbar.tsx';
 import useDialog from '../../hooks/useDialog.tsx';
-import {useMapConfig} from '../../config/MapConfigContext.tsx';
+import {useMapConfig} from '../../context/MapConfigContext.tsx';
 import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 import {createSuggestionRFC} from '../../services/apiService.ts';
 

--- a/src/components/map/MapPOIBottomSheet.tsx
+++ b/src/components/map/MapPOIBottomSheet.tsx
@@ -7,7 +7,7 @@ import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 import {POI} from '../../models/POI/POI.ts';
 import {ScreenState} from '../../interfaces/MapConfig.ts';
 
-import {useMapConfig} from '../../config/MapConfigContext.tsx';
+import {useMapConfig} from '../../context/MapConfigContext.tsx';
 import BaseBottomSheet from '../base/baseBottomSheet.tsx';
 import useSnackbar from '../../hooks/useSnackbar.tsx';
 import useDialog from '../../hooks/useDialog.tsx';

--- a/src/components/map/MapPOIBottomSheet.tsx
+++ b/src/components/map/MapPOIBottomSheet.tsx
@@ -5,7 +5,6 @@ import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 
 import {POI} from '../../models/POI/POI.ts';
-import {ScreenState} from '../../interfaces/MapConfig.ts';
 
 import {useMapConfig} from '../../context/MapConfigContext.tsx';
 import BaseBottomSheet from '../base/baseBottomSheet.tsx';
@@ -16,6 +15,8 @@ import CustomSnackbar from '../CustomSnackbar.tsx';
 import SuggestCancelDialog from './suggestion/SuggestCancelDialog.tsx';
 import SuggestPOIChangeDataSheet from './suggestion/SuggestPOIChangeDataSheet.tsx';
 import {createChangeRFC} from '../../services/apiService.ts';
+import {setFormEditPOI, setViewing} from '../../state/screenStateActions.ts';
+import {ScreenState} from '../../state/screenStateReducer.ts';
 
 interface MapPOIBottomSheetProps {
     poi?: POI;
@@ -26,7 +27,7 @@ interface MapPOIBottomSheetProps {
 export default function MapPOIBottomSheet({ poi, bottomSheetRef, onClose }: MapPOIBottomSheetProps) {
     const {
         screenState,
-        setScreenState,
+        dispatch,
     } = useMapConfig();
 
     const [ snackbarMessage, setSnackbarMessage ] = React.useState<string>('');
@@ -39,7 +40,7 @@ export default function MapPOIBottomSheet({ poi, bottomSheetRef, onClose }: MapP
 
     const handleSuggestChange = () => {
         handleClose();
-        setScreenState(ScreenState.FORM_CHANGE);
+        dispatch(setFormEditPOI());
         handleOpen('dataform');
     };
 
@@ -60,11 +61,11 @@ export default function MapPOIBottomSheet({ poi, bottomSheetRef, onClose }: MapP
                 hide={hideDialog}
                 onSubmit={() => {
                     handleClose();
-                    setScreenState(ScreenState.VIEWING);
+                    dispatch(setViewing());
                 }} onDismiss={() => {}}
             />
 
-            { (screenState === ScreenState.FORM_CHANGE) && (
+            { (screenState === ScreenState.FORM_POI_CHANGE) && (
                 <SuggestPOIChangeDataSheet
                     poi={poi}
                     onCancel={() => {
@@ -77,13 +78,13 @@ export default function MapPOIBottomSheet({ poi, bottomSheetRef, onClose }: MapP
                             setSnackbarMessage('Your suggestion has been submitted!');
                             toggleSnackBar();
 
-                            setScreenState(ScreenState.VIEWING);
+                            dispatch(setViewing());
                         }).catch(() => {
                             setSnackbarMessage('Your suggestion could not be submitted!');
                             toggleSnackBar();
                         });
                     }}
-                    onClose={() => setScreenState(ScreenState.VIEWING)}
+                    onClose={() => dispatch(setViewing())}
                     bottomSheetRef={(ref) => (bottomSheetRef.current.dataform = ref)}
                 />
             )}

--- a/src/components/map/suggestion/MapSuggestLocationBottomSheet.tsx
+++ b/src/components/map/suggestion/MapSuggestLocationBottomSheet.tsx
@@ -31,7 +31,7 @@ export default function MapSuggestLocationBottomSheet({
         >
             <View style={styles.modalDetails}>
                 <TouchableOpacity style={styles.flyButton} onPress={onFlyToLocation}>
-                    <Text style={styles.flyButtonText}>Fly to Location</Text>
+                    <Text style={styles.flyButtonText}>Re-center</Text>
                 </TouchableOpacity>
 
                 <View style={styles.buttonContainer}>

--- a/src/components/map/suggestion/MapSuggestLocationBottomSheet.tsx
+++ b/src/components/map/suggestion/MapSuggestLocationBottomSheet.tsx
@@ -27,6 +27,7 @@ export default function MapSuggestLocationBottomSheet({
             bottomSheetRef={bottomSheetRef}
             index={-1}
             onClose={onClose}
+            enablePanDownToClose={false}
             snapPoints={['20%', '20%']}
         >
             <View style={styles.modalDetails}>

--- a/src/components/map/suggestion/SuggestLocationDataSheet.tsx
+++ b/src/components/map/suggestion/SuggestLocationDataSheet.tsx
@@ -90,7 +90,13 @@ export default function SuggestLocationDataSheet({
     };
 
     return (
-        <BaseBottomSheet bottomSheetRef={bottomSheetRef} index={0} onClose={onClose} snapPoints={['70%', '70%']}>
+        <BaseBottomSheet
+            bottomSheetRef={bottomSheetRef}
+            index={0}
+            onClose={onClose}
+            enablePanDownToClose={false}
+            snapPoints={['70%', '70%']}
+        >
             <View style={styles.modalContent} >
                 <Text variant="titleLarge" style={styles.title}>
                     {poi ? 'Suggest a change' : 'Suggest a Location'}

--- a/src/components/map/suggestion/SuggestPOIButton.tsx
+++ b/src/components/map/suggestion/SuggestPOIButton.tsx
@@ -1,24 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { MD3Theme, Text, useTheme } from 'react-native-paper';
-import { EdgeInsets, useSafeAreaInsets} from 'react-native-safe-area-context';
-
+import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useMapConfig } from '../../../context/MapConfigContext.tsx';
+import { ScreenState } from '../../../state/screenStateReducer.ts';
 
 interface props {
     handleCreateSuggestion: () => void;
-    active: boolean
+    active: boolean;
 }
 
-
-export default function SuggestPOIButton({handleCreateSuggestion, active}: props) {
+export default function SuggestPOIButton({ handleCreateSuggestion, active }: props) {
     const theme = useTheme();
     const insets = useSafeAreaInsets();
     const styles = getStyles(theme, insets, active);
 
+    const { screenState } = useMapConfig();
+    const [isVisible, setIsVisible] = useState(true);
+
+    useEffect(() => {
+        setIsVisible(screenState === ScreenState.VIEWING);
+    }, [screenState]);
+
+    if (!isVisible) {
+        return null;
+    }
+
     return (
         <View style={styles.container}>
-            <TouchableOpacity style={styles.suggestButton}
-                              onPress={handleCreateSuggestion}>
+            <TouchableOpacity style={styles.suggestButton} onPress={handleCreateSuggestion}>
                 <Text style={styles.suggestButtonText}>Suggest POI</Text>
             </TouchableOpacity>
         </View>
@@ -51,7 +61,7 @@ const getStyles = (theme: MD3Theme, insets: EdgeInsets, active: boolean) =>
             justifyContent: 'center',
             alignItems: 'center',
             borderRadius: 6,
-            padding: 5
+            padding: 5,
         },
 
         suggestButtonText: {

--- a/src/context/AppbarContext.tsx
+++ b/src/context/AppbarContext.tsx
@@ -1,0 +1,99 @@
+import React, {createContext, useContext, useState, ReactNode, useCallback} from 'react';
+
+type AppbarContextType = {
+    appbarContent: ReactNode;
+    setAppbarContent: (content: ReactNode) => void;
+    appbarTitle: string;
+    setAppbarTitle: (title: string) => void;
+    centerTitle: boolean;
+    setCenterTitle: (center: boolean) => void;
+    overlapContent: boolean;
+    setOverlapContent: (value: boolean) => void;
+    appbarActions: ReactNode[];
+    setAppbarActions: (actions: ReactNode[]) => void;
+    showAppbar: boolean;
+    setShowAppbar: (show: boolean) => void;
+};
+
+const AppbarContext = createContext<AppbarContextType | undefined>(undefined);
+
+export const AppbarProvider = ({children}: {children: ReactNode}) => {
+    const [appbarContent, setAppbarContent] = useState<ReactNode>(null);
+    const [overlapContent, setOverlapContent] = useState(false); // Default to false
+
+    const [appbarTitle, setAppbarTitle] = useState<string>('');
+    const [centerTitle, setCenterTitle] = useState<boolean>(false);
+
+    const [appbarActions, setAppbarActions] = useState<ReactNode[]>([]);
+    const [showAppbar, setShowAppbar] = useState(false);
+
+    return (
+        <AppbarContext.Provider
+            value={{
+                appbarContent,
+                setAppbarContent,
+                appbarTitle,
+                setAppbarTitle,
+                centerTitle,
+                setCenterTitle,
+                overlapContent,
+                setOverlapContent,
+                appbarActions,
+                setAppbarActions,
+                showAppbar,
+                setShowAppbar,
+            }}>
+            {children}
+        </AppbarContext.Provider>
+    );
+};
+
+export const useAppbar = () => {
+    const context = useContext(AppbarContext);
+    if (!context) {
+        throw new Error('You need to use this inside an AppbarProvider otherwise... kaboom!');
+    }
+
+    const {
+        setAppbarTitle,
+        setAppbarActions,
+        setCenterTitle,
+        setOverlapContent,
+        setShowAppbar,
+    } = context;
+
+    const expandAppbar = useCallback(
+        ({
+             title = '',
+             actions = [],
+             centerTitle = false,
+             overlapContent = false,
+        }: {
+            title?: string;
+            actions?: React.ReactNode[];
+            centerTitle?: boolean;
+            overlapContent?: boolean;
+        }) => {
+            setAppbarTitle(title);
+            setAppbarActions(actions);
+            setCenterTitle(centerTitle);
+            setOverlapContent(overlapContent);
+            setShowAppbar(true);
+        },
+        [setAppbarTitle, setAppbarActions, setCenterTitle, setOverlapContent, setShowAppbar]
+    );
+
+    const collapseAppbar = useCallback(() => {
+        setShowAppbar(false);
+        setAppbarTitle('');
+        setAppbarActions([]);
+        setCenterTitle(false);
+        setOverlapContent(true);
+    }, [setShowAppbar, setAppbarTitle, setAppbarActions, setCenterTitle, setOverlapContent]);
+
+    return {
+        ...context,
+        expandAppbar,
+        collapseAppbar,
+    };
+};

--- a/src/context/MapConfigContext.tsx
+++ b/src/context/MapConfigContext.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useContext, useEffect, useRef, useState} from 'react';
-import MAP_STYLE, {DEFAULT_CENTER, DEFAULT_ZOOM, MAX_ZOOM, MIN_ZOOM} from './MapConfig.ts';
+import MAP_STYLE, {DEFAULT_CENTER, DEFAULT_ZOOM, MAX_ZOOM, MIN_ZOOM} from '../config/MapConfig.ts';
 
 import {CameraRef} from '@maplibre/maplibre-react-native';
 import {IMapConfig, IMapConfigContext, ScreenState} from '../interfaces/MapConfig.ts';
@@ -7,6 +7,7 @@ import {POI} from '../models/POI/POI.ts';
 
 import useLocation from '../hooks/UseLocation.tsx';
 import {fetchPois} from '../services/apiService.ts';
+import {useAppbar} from './AppbarContext.tsx';
 
 
 const defaultConfig: IMapConfig = {
@@ -41,6 +42,7 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
     const cameraRef = useRef<CameraRef>(null);
 
     const { hasLocationPermission, userLocation } = useLocation();
+    const { expandAppbar, collapseAppbar, setAppbarTitle, setCenterTitle, setOverlapContent, setShowAppbar } = useAppbar(); // Access Appbar context
 
     useEffect(() => {
         const loadConfig = async () => {
@@ -57,7 +59,6 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
     }, []);
 
     useEffect(() => {
-
         const loadPois = async () => {
             const loadedPois = await fetchPois('d6a6fbdd-be95-c767-a3f4-4096c91e9cbc');
             setPois(loadedPois);
@@ -65,6 +66,19 @@ export const MapConfigProvider = ({ children }: { children: React.ReactNode}) =>
 
         loadPois();
     }, []);
+
+    useEffect(() => {
+        if (screenState === ScreenState.SUGGESTING) {
+            expandAppbar({
+                title: 'Click on the map to suggest a location',
+                actions: [],
+                centerTitle: true,
+                overlapContent: true,
+            });
+        } else {
+            collapseAppbar();
+        }
+    }, [screenState, collapseAppbar, expandAppbar]);
 
     const handleRecenter = async () => {
         try {

--- a/src/context/MapConfigContext.tsx
+++ b/src/context/MapConfigContext.tsx
@@ -8,7 +8,7 @@ import {POI} from '../models/POI/POI.ts';
 import useLocation from '../hooks/UseLocation.tsx';
 import {fetchPois} from '../services/apiService.ts';
 import {useAppbar} from './AppbarContext.tsx';
-import {ScreenState, screenStateReducer} from '../state/ScreenStateReducer.ts';
+import {ScreenState, screenStateReducer} from '../state/screenStateReducer.ts';
 
 
 const defaultConfig: IMapConfig = {

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -13,11 +13,10 @@ const useBottomSheets = (ids: string[]) => {
     }, [ids]);
 
     const handleOpen = useCallback((id: string) => {
+        Object.values(bottomSheetRefs.current).forEach((ref) => ref?.close());
         Object.entries(bottomSheetRefs.current).forEach(([key, ref]) => {
             if (key === id) {
                 ref?.expand();
-            } else {
-                ref?.close();
             }
         });
     }, []);

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -6,14 +6,14 @@ export default function  useDialog() {
     const showDialog = useCallback((callback?: () => void) => {
         setVisibleDialog(true);
 
-        if (callback) {
+        if (typeof callback === 'function') {
             callback();
         }
     }, []);
     const hideDialog = useCallback((callback?: () => void) => {
         setVisibleDialog(false);
 
-        if (callback) {
+        if (typeof callback === 'function') {
             callback();
         }
     }, []);

--- a/src/interfaces/MapConfig.ts
+++ b/src/interfaces/MapConfig.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import {CameraRef} from '@maplibre/maplibre-react-native';
 import {POI} from '../models/POI/POI.ts';
+import {ScreenState, ScreenStateAction} from '../state/ScreenStateReducer.ts';
 
 export interface IMapConfig {
     mapStyle: any;
@@ -10,18 +11,11 @@ export interface IMapConfig {
     maxZoom: number;
 }
 
-export enum ScreenState {
-    VIEWING,        // Normally viewing the map or an item (details too)
-    SUGGESTING,     // When suggesting a new location (state in between states)
-    FORM_NEW,       // When creating a new POI
-    FORM_CHANGE     // When changing an existing POI
-}
-
 export interface IMapConfigContext {
     config: IMapConfig,
     pois: POI[],
-    screenState: ScreenState,
-    setScreenState: (state: ScreenState) => void,
+    screenState: ScreenState;
+    dispatch: React.Dispatch<ScreenStateAction>;
     loading: boolean,
     userLocation: [number, number] | null,
     hasLocationPermission: boolean,

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BottomNavigation, useTheme } from 'react-native-paper';
 import MapScreen from '../screens/MapScreen';
-import { MapConfigProvider } from '../config/MapConfigContext';
+import { MapConfigProvider } from '../context/MapConfigContext';
 
 function AppNavigator() {
     const theme = useTheme();

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Feature, Point} from 'geojson';
-import {useMapConfig} from '../config/MapConfigContext.tsx';
+import {useMapConfig} from '../context/MapConfigContext.tsx';
 import Loader from '../components/Loader.tsx';
 import {StyleSheet, View} from 'react-native';
 import {Camera, MapView, PointAnnotation} from '@maplibre/maplibre-react-native';
@@ -29,7 +29,7 @@ const MapScreen = () => {
         handleRecenter,
         handleZoomIn,
         handleZoomOut,
-        canInteractWithMap
+        canInteractWithMap,
     } = useMapConfig();
 
     const { bottomSheetRefs, handleOpen, handleClose } = useBottomSheets(['detail', 'location', 'dataform']);

--- a/src/state/screenStateActions.ts
+++ b/src/state/screenStateActions.ts
@@ -1,0 +1,26 @@
+import {ScreenState, ScreenStateAction} from './ScreenStateReducer.ts';
+
+export const setViewing = (): ScreenStateAction => ({
+    type: 'SET_SCREEN',
+    payload: ScreenState.VIEWING,
+});
+
+export const setSuggesting = (): ScreenStateAction => ({
+    type: 'SET_SCREEN',
+    payload: ScreenState.SUGGESTING,
+});
+
+export const setSelectingPOI = (): ScreenStateAction => ({
+    type: 'SET_SCREEN',
+    payload: ScreenState.SELECTING_POI,
+});
+
+export const setFormNewPOI = (): ScreenStateAction => ({
+    type: 'SET_SCREEN',
+    payload: ScreenState.FORM_POI_NEW,
+});
+
+export const setFormEditPOI = (): ScreenStateAction => ({
+    type: 'SET_SCREEN',
+    payload: ScreenState.FORM_POI_CHANGE,
+});

--- a/src/state/screenStateActions.ts
+++ b/src/state/screenStateActions.ts
@@ -1,4 +1,4 @@
-import {ScreenState, ScreenStateAction} from './ScreenStateReducer.ts';
+import {ScreenState, ScreenStateAction} from './screenStateReducer.ts';
 
 export const setViewing = (): ScreenStateAction => ({
     type: 'SET_SCREEN',

--- a/src/state/screenStateReducer.ts
+++ b/src/state/screenStateReducer.ts
@@ -1,0 +1,24 @@
+export enum ScreenState {
+    VIEWING,        // Normally viewing the map or an item (details too)
+    SUGGESTING,     // When suggesting a new location (state in between states)
+    SELECTING_POI,  // When selecting a POI
+    FORM_POI_NEW,       // When creating a new POI
+    FORM_POI_CHANGE     // When changing an existing POI
+}
+
+export type ScreenStateAction = {
+    type: 'SET_SCREEN';
+    payload: ScreenState;
+};
+
+export const screenStateReducer = (
+    state: ScreenState,
+    action: ScreenStateAction
+): ScreenState => {
+    switch (action.type) {
+        case 'SET_SCREEN':
+            return action.payload;
+        default:
+            return state;
+    }
+};


### PR DESCRIPTION
I chose to make the Appbar a dynamic component with a provider so we can always call it when we need it. When its not needed it defaults to hidden and only shows when called. This way we can use it later for different purposes and not just this. I also added a center and overlap paramater to make it multipurpose.

Expanding while not overlapping is still buggy as the idea behind it is that its already collapsed when the content loads. I think thats something we can't realy avoid as we are shrinking and enlarging the content container.